### PR TITLE
Update firebase_authentication_service.dart

### DIFF
--- a/lib/src/firebase_authentication_service.dart
+++ b/lib/src/firebase_authentication_service.dart
@@ -41,7 +41,7 @@ class FirebaseAuthenticationService {
   }
 
   /// Returns the latest userToken stored in the Firebase Auth lib
-  Future<String>? get userToken {
+  Future<String?>? get userToken {
     return firebaseAuth.currentUser?.getIdToken();
   }
 


### PR DESCRIPTION
fix to Error: A value of type 'Future<String?>?' can't be returned from a function with return type 'Future<String>?' because 'String?' is nullable and 'String' isn't.