### PR TITLE
fix: downgrade logger dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   sign_in_with_apple: ^4.3.0
 
   # logging
-  logger: ^2.0.0
+  logger: ^1.4.0
 
   crypto: ^3.0.3
 


### PR DESCRIPTION
Downgrade `logger` dependency to avoid conflicts on `stacked_generator` package.