### PR TITLE
Add ability to specify scopes for Google Services when using Google Sign In

### DIFF
--- a/lib/src/firebase_authentication_service.dart
+++ b/lib/src/firebase_authentication_service.dart
@@ -52,7 +52,6 @@ class FirebaseAuthenticationService {
   bool get hasUser {
     return firebaseAuth.currentUser != null;
   }
-  
   /// Exposes the authStateChanges functionality.
   Stream<User?> get authStateChanges {
     return firebaseAuth.authStateChanges();
@@ -86,9 +85,7 @@ class FirebaseAuthenticationService {
         GoogleAuthProvider googleProvider = GoogleAuthProvider();
         googleProvider.setCustomParameters(
             {'login_hint': webLoginHint ?? 'user@example.com'});
-        for (var scope in scopes ?? []) {
-          googleProvider.addScope(scope);
-        }
+        (scopes ?? []).forEach(googleProvider.addScope);
         userCredential = await FirebaseAuth.instance.signInWithPopup(
           googleProvider,
         );

--- a/lib/src/firebase_authentication_service.dart
+++ b/lib/src/firebase_authentication_service.dart
@@ -17,7 +17,7 @@ class FirebaseAuthenticationService {
   final Logger? log;
 
   final firebaseAuth = FirebaseAuth.instance;
-  final GoogleSignIn _googleSignIn = GoogleSignIn();
+  GoogleSignIn? _googleSignIn;
 
   FirebaseAuthenticationService({
     @Deprecated(
@@ -52,6 +52,7 @@ class FirebaseAuthenticationService {
   bool get hasUser {
     return firebaseAuth.currentUser != null;
   }
+
   /// Exposes the authStateChanges functionality.
   Stream<User?> get authStateChanges {
     return firebaseAuth.authStateChanges();
@@ -94,8 +95,9 @@ class FirebaseAuthenticationService {
       /// On native platforms, a 3rd party library, like GoogleSignIn, is
       /// required to trigger the authentication flow.
       else {
+        _googleSignIn = GoogleSignIn(scopes: scopes ?? []);
         final GoogleSignInAccount? googleSignInAccount =
-            await _googleSignIn.signIn();
+            await _googleSignIn!.signIn();
         if (googleSignInAccount == null) {
           log?.i('Process is canceled by the user');
           return FirebaseAuthenticationResult.error(
@@ -508,7 +510,7 @@ class FirebaseAuthenticationService {
     try {
       _clearPendingData();
       await firebaseAuth.signOut();
-      await _googleSignIn.signOut();
+      await _googleSignIn?.signOut();
       await FacebookAuth.instance.logOut();
     } catch (e) {
       log?.e('Could not sign out of social account. $e');

--- a/lib/src/firebase_authentication_service.dart
+++ b/lib/src/firebase_authentication_service.dart
@@ -52,7 +52,7 @@ class FirebaseAuthenticationService {
   bool get hasUser {
     return firebaseAuth.currentUser != null;
   }
-
+  
   /// Exposes the authStateChanges functionality.
   Stream<User?> get authStateChanges {
     return firebaseAuth.authStateChanges();
@@ -77,17 +77,18 @@ class FirebaseAuthenticationService {
   ///   - iOS
   ///   - Web
   Future<FirebaseAuthenticationResult> signInWithGoogle(
-      {String? webLoginHint}) async {
+      {String? webLoginHint, List<String>? scopes}) async {
     try {
       UserCredential userCredential;
-
       /// On the web, the Firebase SDK provides support for automatically
       /// handling the authentication flow.
       if (kIsWeb) {
         GoogleAuthProvider googleProvider = GoogleAuthProvider();
         googleProvider.setCustomParameters(
             {'login_hint': webLoginHint ?? 'user@example.com'});
-
+        for (var scope in scopes ?? []) {
+          googleProvider.addScope(scope);
+        }
         userCredential = await FirebaseAuth.instance.signInWithPopup(
           googleProvider,
         );

--- a/lib/src/firebase_authentication_service.dart
+++ b/lib/src/firebase_authentication_service.dart
@@ -17,7 +17,6 @@ class FirebaseAuthenticationService {
   final Logger? log;
 
   final firebaseAuth = FirebaseAuth.instance;
-  String? _oAuthAccessToken;
   GoogleSignIn? _googleSignIn;
 
   FirebaseAuthenticationService({
@@ -36,17 +35,12 @@ class FirebaseAuthenticationService {
   Future<UserCredential> _signInWithCredential(
     AuthCredential credential,
   ) async {
-    _oAuthAccessToken = credential.accessToken;
     return await firebaseAuth.signInWithCredential(credential);
   }
 
   /// Returns the current logged in Firebase User
   User? get currentUser {
     return firebaseAuth.currentUser;
-  }
-
-  String? get oAuthAccessToken {
-    return _oAuthAccessToken;
   }
 
   /// Returns the latest userToken stored in the Firebase Auth lib
@@ -86,6 +80,7 @@ class FirebaseAuthenticationService {
       {String? webLoginHint, List<String>? scopes}) async {
     try {
       UserCredential userCredential;
+
       /// On the web, the Firebase SDK provides support for automatically
       /// handling the authentication flow.
       if (kIsWeb) {
@@ -119,7 +114,6 @@ class FirebaseAuthenticationService {
           idToken: googleSignInAuthentication.idToken,
         );
 
-        _oAuthAccessToken = googleSignInAuthentication.accessToken;
         userCredential = await _signInWithCredential(credential);
       }
 
@@ -611,7 +605,8 @@ class FirebaseAuthenticationResult {
   final String? errorMessage;
   final String? exceptionCode;
 
-  FirebaseAuthenticationResult({this.user, this.additionalUserInfo, this.oAuthAccessToken})
+  FirebaseAuthenticationResult(
+      {this.user, this.additionalUserInfo, this.oAuthAccessToken})
       : errorMessage = null,
         exceptionCode = null;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: stacked_firebase_auth
 description: A service class that provides Firebase Authentication Functionality on a single api
 version: 2.20.0
 homepage: https://stacked.filledstacks.com/
-repository: https://github.com/Stacked-Org/firebase_auth.git
+repository: https://github.com/pmmucsd/firebase_auth.git
 issue_tracker: https://github.com/Stacked-Org/framework/issues
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: stacked_firebase_auth
+name: firebase_auth
 description: A service class that provides Firebase Authentication Functionality on a single api
 version: 2.20.0
 homepage: https://stacked.filledstacks.com/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,8 +1,8 @@
-name: firebase_auth
+name: stacked_firebase_auth
 description: A service class that provides Firebase Authentication Functionality on a single api
 version: 2.20.0
 homepage: https://stacked.filledstacks.com/
-repository: https://github.com/pmmucsd/firebase_auth.git
+repository: https://github.com/pmmucsd/stacked_firebase_auth.git
 issue_tracker: https://github.com/Stacked-Org/framework/issues
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   # Firebase
-  firebase_core: ^2.15.0
+  firebase_core: ^3.8.0
   firebase_auth: ^4.7.1
   firebase_auth_platform_interface: ^7.0.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   # Firebase
   firebase_core: ^3.8.0
-  firebase_auth: ^4.7.1
+  firebase_auth: ^5.3.3
   firebase_auth_platform_interface: ^7.0.0
 
   # Firebase Authentications


### PR DESCRIPTION
Adds the ability to pass in a list of scopes and returns the oAuth access token with the FirebaseAuthenticationResult. This enables developers to use this library to request access to Google Services like Drive and Gmail in the signup flow. 