### PR TITLE
fix: export `firebase_core` package

### DIFF
--- a/lib/stacked_firebase_auth.dart
+++ b/lib/stacked_firebase_auth.dart
@@ -4,3 +4,4 @@ export 'src/firebase_authentication_service.dart';
 export 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart'
     show FirebaseAuthException;
 export 'package:firebase_auth/firebase_auth.dart' show User;
+export 'package:firebase_core/firebase_core.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,22 +13,22 @@ dependencies:
     sdk: flutter
 
   # Firebase
-  firebase_core: ^2.15.0
-  firebase_auth: ^4.7.1
+  firebase_core: ^2.32.0
+  firebase_auth: ^4.20.0
   firebase_auth_platform_interface: ^7.0.0
 
   # Firebase Authentications
-  google_sign_in: ^6.1.4
-  sign_in_with_apple: ^5.0.0
-  flutter_facebook_auth: ^6.0.4
+  google_sign_in: ^6.2.1
+  sign_in_with_apple: ^6.1.1
+  flutter_facebook_auth: ^6.2.0
 
   # logging
-  logger: ^1.4.0
+  logger: ^2.3.0
 
   crypto: ^3.0.3
 
 dev_dependencies:
-  flutter_lints: ^3.0.0
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
- Exported firebase_core package to avoid adding the dependency on the client app. For example, when calling Firebase.initializeApp().
- Updated packages