### PR TITLE
feat: add validateOtpAndLinkPhoneNumber method

### DIFF
--- a/example/lib/ui/views/secured_area/secured_area_view.dart
+++ b/example/lib/ui/views/secured_area/secured_area_view.dart
@@ -5,7 +5,7 @@ import 'package:stacked/stacked.dart';
 import 'secured_area_viewmodel.dart';
 
 class SecuredAreaView extends StackedView<SecuredAreaViewModel> {
-  const SecuredAreaView({Key? key}) : super(key: key);
+  const SecuredAreaView({super.key});
 
   @override
   Widget builder(
@@ -14,7 +14,7 @@ class SecuredAreaView extends StackedView<SecuredAreaViewModel> {
     Widget? child,
   ) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.surface,
       body: Container(
         padding: const EdgeInsets.only(left: 25.0, right: 25.0),
         child: Center(

--- a/lib/src/firebase_authentication_service.dart
+++ b/lib/src/firebase_authentication_service.dart
@@ -59,6 +59,10 @@ class FirebaseAuthenticationService {
   }
 
   /// Returns `true` when email has a user registered
+  @Deprecated(
+    'emailExists() has been deprecated. '
+    'Migrating off of this method is recommended as a security best-practice. Learn more in the Identity Platform documentation: ',
+  )
   Future<bool> emailExists(String email) async {
     try {
       final signInMethods =
@@ -620,8 +624,16 @@ class FirebaseAuthenticationService {
   }
 
   /// Update the [email] of the Firebase User
+  @Deprecated(
+    'updateEmail() has been deprecated. Please use verifyBeforeUpdateEmail() instead.',
+  )
   Future<void> updateEmail(String email) async {
     await firebaseAuth.currentUser?.updateEmail(email);
+  }
+
+  /// Sends a verification email to a new email address. The user's email will be updated to the new one after being verified.
+  Future<void> verifyBeforeUpdateEmail(String email) async {
+    await firebaseAuth.currentUser?.verifyBeforeUpdateEmail(email);
   }
 
   /// Update the [displayName] of the Firebase User

--- a/lib/src/firebase_authentication_service.dart
+++ b/lib/src/firebase_authentication_service.dart
@@ -503,6 +503,38 @@ class FirebaseAuthenticationService {
     }
   }
 
+  /// Validate phone number using the [otp] and link it with user account
+  Future<void> validateOtpAndLinkPhoneNumber(
+    String otp,
+  ) async {
+    if (_mobileVerificationId == null) {
+      throw 'The _mobileVerificationId should not be null here. Verification was probably skipped.';
+    }
+
+    try {
+      final phoneAuthCredential = PhoneAuthProvider.credential(
+        verificationId: _mobileVerificationId!,
+        smsCode: otp,
+      );
+
+      await firebaseAuth.currentUser?.linkWithCredential(
+        phoneAuthCredential,
+      );
+    } on FirebaseAuthException catch (e) {
+      log?.e('A Firebase exception has occurred. $e');
+      throw FirebaseAuthenticationResult.error(
+        exceptionCode: e.code.toLowerCase(),
+        errorMessage: getErrorMessageFromFirebaseException(e),
+      );
+    } on Exception catch (e) {
+      log?.e('A general exception has occurred. $e');
+      throw FirebaseAuthenticationResult.error(
+        errorMessage:
+            'We could not link your phone number at this time. Please try again.',
+      );
+    }
+  }
+
   /// Sign out of the social accounts that have been used
   Future logout() async {
     log?.i('logout');

--- a/lib/src/firebase_authentication_service.dart
+++ b/lib/src/firebase_authentication_service.dart
@@ -564,7 +564,7 @@ class FirebaseAuthenticationService {
   }
 
   /// Sign out of the social accounts that have been used
-  Future logout() async {
+  Future<void> logout() async {
     log?.i('logout');
 
     try {
@@ -582,7 +582,7 @@ class FirebaseAuthenticationService {
   }
 
   /// Send reset password link to email
-  Future sendResetPasswordLink(String email) async {
+  Future<bool> sendResetPasswordLink(String email) async {
     log?.i('email:$email');
 
     try {
@@ -595,7 +595,7 @@ class FirebaseAuthenticationService {
   }
 
   /// Validate the current [password] of the Firebase User
-  Future validatePassword(String password) async {
+  Future<dynamic> validatePassword(String password) async {
     try {
       final authCredentials = EmailAuthProvider.credential(
         email: firebaseAuth.currentUser?.email ?? '',
@@ -609,27 +609,28 @@ class FirebaseAuthenticationService {
     } catch (e) {
       log?.e('Could not validate the user password. $e');
       return FirebaseAuthenticationResult.error(
-          errorMessage: 'The current password is not valid.');
+        errorMessage: 'The current password is not valid.',
+      );
     }
   }
 
   /// Update the [password] of the Firebase User
-  Future updatePassword(String password) async {
+  Future<void> updatePassword(String password) async {
     await firebaseAuth.currentUser?.updatePassword(password);
   }
 
   /// Update the [email] of the Firebase User
-  Future updateEmail(String email) async {
+  Future<void> updateEmail(String email) async {
     await firebaseAuth.currentUser?.updateEmail(email);
   }
 
   /// Update the [displayName] of the Firebase User
-  Future updateDisplayName(String displayName) async {
+  Future<void> updateDisplayName(String displayName) async {
     await firebaseAuth.currentUser?.updateDisplayName(displayName);
   }
 
   /// Update the [photoURL] of the Firebase User
-  Future updatePhotoURL(String photoUrl) async {
+  Future<void> updatePhotoURL(String photoUrl) async {
     await firebaseAuth.currentUser?.updatePhotoURL(photoUrl);
   }
 


### PR DESCRIPTION
Added `validateOtpAndLinkPhoneNumber` method to allow validation of phone number without implicit sign in of the user. Instead of that, we link the phone number to the existing account.